### PR TITLE
Bugfixes & Accommodate larger volume of terms

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ async function generateAPR(terms: string[]): Promise<string> {
 }
 
 async function main() {
-  const terms = ["dai", "stecrv", "lusd3crv-f", "crvtricrypto", "crv3crypto", "usdc"];
+  const terms = ["wbtc","dai", "stecrv", "lusd3crv-f", "crvtricrypto", "crv3crypto", "usdc"];
   const data: string = await generateAPR(terms);
   console.log(data);
   await sendTweet(data);

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import { calcSpotPricePt } from "../elf-sdk/src/helpers/calcSpotPrice";
 import { calcFixedAPR } from "../elf-sdk/src/helpers/calcFixedAPR";
 import { ONE_DAY_IN_SECONDS } from "../elf-sdk/src/constants/time";
 
-const termMap = {"dai":"DAI", "usdc":"USDC", "stecrv":"crvSTETH", "lusd3crv-f":"crvLUSD", "crvtricrypto":"crvTriCrypto", "crv3crypto": "crv3Crypto"};
+const termMap = {"wbtc":"wBTC","dai":"DAI", "usdc":"USDC", "stecrv":"crvSTETH", "lusd3crv-f":"crvLUSD", "crvtricrypto":"crvTriCrypto", "crv3crypto": "crv3Crypto"};
 
 async function sendTweet(tweetBody: string) {
   // Initialize Twitter env variables

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ async function main() {
 
   const data: string = await generateAPR(terms);
   console.log(data);
-  //await sendTweet(data);
+  await sendTweet(data);
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ async function generateAPR(terms: string[]): Promise<string> {
       }
     }
   }
-  body += "Asset APR (Days Remaining)\n\nRates currently available at http://save.element.fi";
+  body += "Asset APR (Days Remaining)\n\nRates currently available at https://app.element.fi/fixedrates/";
   return body;
 }
 


### PR DESCRIPTION
Makes improvements listed below. Solution is still a little hacky/messy, but a larger restructure of the twitter bot will be coming in the next week or so to take advantage of the recent updates to the elf-sdk.

- Updates the link to the Element app after the UI updates. (Fixes #9)

- Condenses terms of the same type to a single line
e.g. USDC: 6.74% (42d), 4.38% (133d) instead of two separate lines prefaced with USDC

- With the increased volume of terms listed on element.fi, we've run out of space to list all terms in a single tweet. To accommodate this, we've chosen wBTC, crvSTETH, and USDC as the more popular terms to always show in the daily tweet. We then randomly select two of the remaining terms to also show in the tweet, and we've added "Find more rates available at..." to the last line with the URL

- Add wBTC to the term format map

Tweets will now look like:

```
Today's @element_fi Fixed Rate Report🌤

wBTC: 3.46% (70d)
crvSTETH: 8.25% (29d), 5.93% (133d)
USDC: 6.74% (42d), 4.38% (133d)
crv3Crypto: 25.53% (57d)
crvLUSD: 11.79% (11d), 13.06% (101d)
Asset APR (Days Remaining)

Find more rates available at https://app.element.fi/fixedrates/
```

(Note: Twitter should format the app to be a hyperlink that doesn't show the "https://" preface)


